### PR TITLE
surround round(tend) with try block

### DIFF
--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -1669,7 +1669,10 @@ class Extractor(object):
 
                                     if 'stimuli' not in stim[stimname]:
 
-                                        totduration = round(tend)
+                                        try:
+                                            totduration = round(tend)
+                                        except ValueError:
+                                            totduration = numpy.NaN
                                         delay = round(
                                             self.options["delay"] + ton)
                                         duration = round(toff - ton)


### PR DESCRIPTION
This was causing py3-functional tests to fail in Ubuntu 18.10 and 19.10 platforms