### PR TITLE
Fix reader of NWB containing repetitions with leading zeros

### DIFF
--- a/bluepyefe/reader.py
+++ b/bluepyefe/reader.py
@@ -206,14 +206,14 @@ def nwb_reader_BBP(in_data):
             raise Exception(
                 f"No eCode {ecode} in nwb  {in_data['filepath']}."
             )
-        
+
         av_reps = list(r["data_organization"][cell_id][ecode].keys())
-        av_reps_id = [int(e.replace('repetition','').strip()) for e in av_reps] 
-        
+        av_reps_id = [int(rep.replace("repetition ", "")) for rep in av_reps]
+
         if "repetition" in in_data and in_data["repetition"]:
             if isinstance(in_data["repetition"], list):
-                rep_iter = [av_reps[av_reps_id.index(i)] 
-                            for i in in_data['repetition']]
+                rep_iter = [av_reps[av_reps_id.index(i)]
+                            for i in in_data["repetition"]]
             else:
                 rep_iter = [av_reps[av_reps_id.index(in_data["repetition"])]]
         else:

--- a/bluepyefe/reader.py
+++ b/bluepyefe/reader.py
@@ -206,12 +206,16 @@ def nwb_reader_BBP(in_data):
             raise Exception(
                 f"No eCode {ecode} in nwb  {in_data['filepath']}."
             )
-
+        
+        av_reps = list(r["data_organization"][cell_id][ecode].keys())
+        av_reps_id = [int(e.replace('repetition','').strip()) for e in av_reps] 
+        
         if "repetition" in in_data and in_data["repetition"]:
             if isinstance(in_data["repetition"], list):
-                rep_iter = [f"repetition {i}" for i in in_data['repetition']]
+                rep_iter = [av_reps[av_reps_id.index(i)] 
+                            for i in in_data['repetition']]
             else:
-                rep_iter = [f"repetition {in_data['repetition']}"]
+                rep_iter = [av_reps[av_reps_id.index(in_data["repetition"])]]
         else:
             rep_iter = r["data_organization"][cell_id][ecode].keys()
 


### PR DESCRIPTION
In the temporary new NWB reader, allow parsing of both "repetition n" and "repetition 0n" groups (with leading zeros).