### PR TITLE
Adjust amplitude use in_target for HyperDepol

### DIFF
--- a/bluepyefe/ecode/HyperDePol.py
+++ b/bluepyefe/ecode/HyperDePol.py
@@ -179,7 +179,7 @@ class HyperDePol(Recording):
     def in_target(self, target, tolerance):
         """Returns a boolean. True if the amplitude of the eCode is close to
         target and False otherwise."""
-        if numpy.abs(target - self.amp2_rel) < tolerance:
+        if numpy.abs(target - self.amp_rel) < tolerance:
             return True
         else:
             return False


### PR DESCRIPTION
Use `self.amp_rel` instead of `self.amp2_rel` in the `in_target` function for `HyperDepol`, since it's the hyperpolarization phase that is changed in the ecode protocols