### PR TITLE
Minor changes to eCode detection and fix double extraction of some features

### DIFF
--- a/bluepyefe/cell.py
+++ b/bluepyefe/cell.py
@@ -97,7 +97,7 @@ class Cell(object):
             for reader_data in self.reader(config_data, recording_reader):
 
                 for ecode in eCodes.keys():
-                    if ecode in protocol_name.lower():
+                    if ecode.lower() in protocol_name.lower():
                         rec = eCodes[ecode](
                             config_data, reader_data, protocol_name
                         )

--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -88,6 +88,11 @@ def _extract_efeatures_cell(cell, targets, efel_settings=None):
                 'efeatures': [target["efeature"]]
             })
 
+    for i, group in enumerate(setting_groups):
+        setting_groups[i]["efeatures"] = list(
+            set(setting_groups[i]["efeatures"])
+        )
+
     for group in setting_groups:
         cell.extract_efeatures(
             group['protocol'],

--- a/bluepyefe/protocol.py
+++ b/bluepyefe/protocol.py
@@ -96,8 +96,10 @@ class Protocol():
         if not self.recordings:
             return None
 
-        if self.name.lower() in eCodes:
-            ecode = eCodes[self.name.lower()]({}, {}, self.name)
+        for ecode in eCodes.keys():
+            if ecode.lower() in self.name.lower():
+                ecode = eCodes[ecode]({}, {}, self.name)
+            break
         else:
             raise KeyError(
                 "There is no eCode linked to the stimulus name {}. See "


### PR DESCRIPTION
- Made the list of efeatures a set in _extract_efeatures_cell to avoid extracting twice the same features if it is asked for several different amplitudes
- Minor changes to the way we check which eCodes name is present in the protocol name.