### PR TITLE
Proposal to add optional efeature_names to target

### DIFF
--- a/bluepyefe/cell.py
+++ b/bluepyefe/cell.py
@@ -121,6 +121,7 @@ class Cell(object):
             self,
             protocol_name,
             efeatures,
+            efeature_names=None,
             efel_settings=None
     ):
         """
@@ -128,7 +129,8 @@ class Cell(object):
         """
 
         for i in self.get_recordings_id_by_protocol_name(protocol_name):
-            self.recordings[i].compute_efeatures(efeatures, efel_settings)
+            self.recordings[i].compute_efeatures(
+                efeatures, efeature_names, efel_settings)
 
     def compute_relative_amp(self):
         """

--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -99,11 +99,6 @@ def _extract_efeatures_cell(cell, targets, efel_settings=None):
             }
             setting_groups.append(setting_group)
 
-    for i, group in enumerate(setting_groups):
-        setting_groups[i]["efeatures"] = list(
-            set(setting_groups[i]["efeatures"])
-        )
-
     for group in setting_groups:
         cell.extract_efeatures(
             group['protocol'],

--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -85,11 +85,16 @@ def _extract_efeatures_cell(cell, targets, efel_settings=None):
                 setting_groups[i]["efeatures"].append(target["efeature"])
                 break
         else:
-            setting_groups.append({
+            setting_group = {
                 'efel_settings': target["efel_settings"],
                 'protocol': target["protocol"],
                 'efeatures': [target["efeature"]]
-            })
+            }
+            if "efeature_name" in target:
+                setting_group['efeature_names'] = [target["efeature_name"]]
+            else:
+                setting_group['efeature_names'] = None
+            setting_groups.append(setting_group)
 
     for i, group in enumerate(setting_groups):
         setting_groups[i]["efeatures"] = list(
@@ -100,6 +105,7 @@ def _extract_efeatures_cell(cell, targets, efel_settings=None):
         cell.extract_efeatures(
             group['protocol'],
             group["efeatures"],
+            group["efeature_names"],
             efel_settings={**efel_settings, **group["efel_settings"]}
         )
 

--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -299,8 +299,10 @@ def _build_protocols(
     for target in targets:
 
         efel_settings = {**efel_settings, **target.get('efel_settings', {})}
+        efeature_name = target.get("efeature_name", target["efeature"])
 
         efeature_target = EFeatureTarget(
+            efeature_name=efeature_name,
             efel_feature_name=target['efeature'],
             protocol_name=target['protocol'],
             amplitude=target['amplitude'],

--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -79,21 +79,24 @@ def _extract_efeatures_cell(cell, targets, efel_settings=None):
     setting_groups = []
     for target in targets:
 
+        efeature_name = target.get("efeature_name", target["efeature"])
+
         for i, group in enumerate(setting_groups):
+
             if target["efel_settings"] == group['efel_settings'] and \
                     target["protocol"] == group['protocol']:
                 setting_groups[i]["efeatures"].append(target["efeature"])
+                setting_groups[i]['efeature_names'].append(efeature_name)
                 break
+
         else:
+
             setting_group = {
                 'efel_settings': target["efel_settings"],
                 'protocol': target["protocol"],
-                'efeatures': [target["efeature"]]
+                'efeatures': [target["efeature"]],
+                'efeature_names': [efeature_name]
             }
-            if "efeature_name" in target:
-                setting_group['efeature_names'] = [target["efeature_name"]]
-            else:
-                setting_group['efeature_names'] = None
             setting_groups.append(setting_group)
 
     for i, group in enumerate(setting_groups):

--- a/bluepyefe/protocol.py
+++ b/bluepyefe/protocol.py
@@ -120,9 +120,9 @@ class Protocol():
         """Append a Recording to the present protocol"""
 
         for i, target in enumerate(self.feature_targets):
-            if target.efel_feature_name in recording.efeatures:
+            if target.efeature_name in recording.efeatures:
                 self.feature_targets[i].append(
-                    recording.efeatures[target.efel_feature_name],
+                    recording.efeatures[target.efeature_name],
                     recording.files
                 )
 

--- a/bluepyefe/recording.py
+++ b/bluepyefe/recording.py
@@ -177,18 +177,19 @@ class Recording(object):
                 raise Exception("One of the following feature name does not "
                                 f"exist in eFEL: {str_f}")
 
-    def compute_efeatures(self, efeatures, efel_settings=None):
+    def compute_efeatures(self, efeatures, efeature_names=None, efel_settings=None):
         """ Compute a set of efeatures """
 
+        if efeature_names is None:
+            efeature_names = efeatures
         efel_vals = self.call_efel(efeatures, efel_settings)
-
-        for efeature in efeatures:
+        for efeature_name, efeature in zip(efeature_names, efeatures):
 
             value = efel_vals[0][efeature]
             if value is None or numpy.isinf(numpy.nanmean(value)):
                 value = numpy.nan
 
-            self.efeatures[efeature] = numpy.nanmean(value)
+            self.efeatures[efeature_name] = numpy.nanmean(value)
 
     def compute_spikecount(self, efel_settings=None):
         """Compute the number of spikes in the trace"""

--- a/bluepyefe/recording.py
+++ b/bluepyefe/recording.py
@@ -182,6 +182,7 @@ class Recording(object):
 
         if efeature_names is None:
             efeature_names = efeatures
+
         efel_vals = self.call_efel(efeatures, efel_settings)
         for efeature_name, efeature in zip(efeature_names, efeatures):
 

--- a/bluepyefe/recording.py
+++ b/bluepyefe/recording.py
@@ -177,7 +177,9 @@ class Recording(object):
                 raise Exception("One of the following feature name does not "
                                 f"exist in eFEL: {str_f}")
 
-    def compute_efeatures(self, efeatures, efeature_names=None, efel_settings=None):
+    def compute_efeatures(
+        self, efeatures, efeature_names=None, efel_settings=None
+    ):
         """ Compute a set of efeatures """
 
         if efeature_names is None:

--- a/bluepyefe/rheobase.py
+++ b/bluepyefe/rheobase.py
@@ -95,7 +95,9 @@ def compute_rheobase_flush(cell, protocols_rheobase, flush_length=1):
 
             end_flush = min(i + 1 + flush_length, len(amps))
 
-            if numpy.count_nonzero(spike_counts[i + 1:end_flush]) == flush_length:
+            if (
+                numpy.count_nonzero(spike_counts[i + 1:end_flush]) == flush_length
+            ):
                 cell.rheobase = amp
                 break
 

--- a/bluepyefe/target.py
+++ b/bluepyefe/target.py
@@ -31,6 +31,7 @@ class EFeatureTarget():
 
     def __init__(
             self,
+            efeature_name,
             efel_feature_name,
             protocol_name,
             amplitude,
@@ -40,6 +41,8 @@ class EFeatureTarget():
         """Constructor
 
         Args:
+            efeature_name (str): name of the feature (can be different than
+                the efel_feature_name - e.g. Spikecount_phase1)
             efel_feature_name (str): name of the eFeature in the eFEL library
                 (ex: 'AP1_peak')
             protocol_name (str): name of the recording from which the efeature
@@ -53,7 +56,7 @@ class EFeatureTarget():
                 threshold amplitude (rheobase))
             efel_settings (dict): target specific efel settings.
         """
-
+        self.efeature_name = efeature_name
         self.efel_feature_name = efel_feature_name
         self.protocol_name = protocol_name
 
@@ -117,6 +120,7 @@ class EFeatureTarget():
         """Returns the target in the form of a dictionary"""
 
         return {
+            "efeature_name": self.efeature_name,
             "feature": self.efel_feature_name,
             "mean": self.mean,
             "std": self.std,

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -77,6 +77,13 @@ class ExtractorTest(unittest.TestCase):
 
         bluepyefe.extract.compute_rheobase(cells, protocols_rheobase=["IDRest"])
 
+        self.assertEqual(len(cells), 2)
+        self.assertEqual(len(cells[0].recordings), 5)
+        self.assertEqual(len(cells[1].recordings), 5)
+
+        self.assertLess(abs(cells[0].rheobase - 0.119), 0.01)
+        self.assertLess(abs(cells[1].rheobase - 0.0923), 0.01)
+
         protocols = bluepyefe.extract.group_efeatures(
             cells,
             targets,
@@ -87,13 +94,6 @@ class ExtractorTest(unittest.TestCase):
         _ = bluepyefe.extract.create_feature_protocol_files(
             cells=cells, protocols=protocols, output_directory="MouseCells"
         )
-
-        self.assertEqual(len(cells), 2)
-        self.assertEqual(len(cells[0].recordings), 5)
-        self.assertEqual(len(cells[1].recordings), 5)
-
-        self.assertLess(abs(cells[0].rheobase - 0.119), 0.01)
-        self.assertLess(abs(cells[1].rheobase - 0.0923), 0.01)
 
         for protocol in protocols:
             if protocol.name == "IDRest" and protocol.amplitude == 250.:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -11,6 +11,7 @@ class TestProtocol(unittest.TestCase):
 
     def setUp(self):
         target = EFeatureTarget(
+            efeature_name='test_spikecount',
             efel_feature_name='Spikecount',
             protocol_name='IDRest',
             amplitude=150.,
@@ -28,7 +29,7 @@ class TestProtocol(unittest.TestCase):
     def test_append_clear(self):
 
         rec = Recording("IDRest", {}, {})
-        rec.efeatures = {"Spikecount": 10.}
+        rec.efeatures = {"test_spikecount": 10.}
 
         self.protocol.append(rec)
         self.protocol.append(rec)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -11,6 +11,7 @@ class TestEFeatureTarget(unittest.TestCase):
 
     def setUp(self):
         self.target = EFeatureTarget(
+            efeature_name='test_spikecount',
             efel_feature_name='Spikecount',
             protocol_name='IDRest',
             amplitude=150.,
@@ -47,7 +48,7 @@ class TestEFeatureTarget(unittest.TestCase):
         self.target.append(1.)
         self.target.append(2.)
         dict_form = self.target.as_dict()
-        self.assertEqual(len(dict_form), 8)
+        self.assertEqual(len(dict_form), 9)
         self.assertEqual(dict_form['mean'], 1.5)
         dict_form_legacy = self.target.as_legacy_dict()
         self.assertEqual(len(dict_form_legacy), 4)


### PR DESCRIPTION
In order to allow to extract multiple features with the same feature name from the same recording (e.g. multiple spikecounts for PosCheops), I added an optional `efeature_name` for the targets. If `efeature_name` is given, then the recording can store multiple features of the same type.