### PR TITLE
Custom github action to keep the cron workflows alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,9 +1,11 @@
 name: Keep-alive
 
 on:
+
   schedule:
     # Runs every sunday at 3 a.m.
-    - cron: '0 3 * * SUN'
+    # Reset to '0 3 * * SUN' before MR
+    - cron: '0 13 * * FRI'
 
 jobs:
   call-test-workflow:
@@ -16,4 +18,26 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: master
-      - uses: gautamkrishnar/keepalive-workflow@master
+
+      - name: Get date from 50 days ago
+        run: |
+          datethen=`date -d "-50 days" --utc +%FT%TZ`
+          echo "datelimit=$datethen" >> $GITHUB_ENV
+
+      - name: Get date from 1 hour ago
+        run: |
+          datethen2=`date -d "-1 hour" --utc +%FT%TZ`
+          echo "datelimit=$datethen2" >> $GITHUB_ENV
+
+      - name: setup git config
+        if: github.event.base.repo.updated_at <= env.datelimit2
+        run: |
+          # setup the username and email.
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+
+      - name: commit
+        if: github.event.base.repo.updated_at <= env.datelimit2
+        run: |
+          git commit -m "Empty commit to keep the gihub workflows alive" --allow-empty
+          git push origin master

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -3,8 +3,7 @@ name: Keep-alive
 on:
   schedule:
     # Runs every sunday at 3 a.m.
-    # Reset to '0 3 * * SUN' before MR
-    - cron: '0 1 * * *'
+    - cron: '0 3 * * SUN'
 
 jobs:
   call-test-workflow:
@@ -23,20 +22,15 @@ jobs:
           datethen=`date -d "-50 days" --utc +%FT%TZ`
           echo "datelimit=$datethen" >> $GITHUB_ENV
 
-      - name: Get date from 1 hour ago
-        run: |
-          datethen2=`date -d "-1 hour" --utc +%FT%TZ`
-          echo "datelimit=$datethen2" >> $GITHUB_ENV
-
       - name: setup git config
-        if: github.event.base.repo.updated_at <= env.datelimit2
+        if: github.event.base.repo.updated_at <= env.datelimit
         run: |
           # setup the username and email.
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
-      - name: commit
-        if: github.event.base.repo.updated_at <= env.datelimit2
+      - name: commit IF last commit is older than 50 days
+        if: github.event.base.repo.updated_at <= env.datelimit
         run: |
           git commit -m "Empty commit to keep the gihub workflows alive" --allow-empty
           git push origin master

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -26,7 +26,7 @@ jobs:
         if: github.event.base.repo.updated_at <= env.datelimit
         run: |
           # setup the username and email.
-          git config user.name "GitHub Actions Bot"
+          git config user.name "Github Actions Keepalive Bot"
           git config user.email "<>"
 
       - name: commit IF last commit is older than 50 days

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,7 +1,6 @@
 name: Keep-alive
 
 on:
-
   schedule:
     # Runs every sunday at 3 a.m.
     # Reset to '0 3 * * SUN' before MR

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     # Runs every sunday at 3 a.m.
     # Reset to '0 3 * * SUN' before MR
-    - cron: '0 13 * * FRI'
+    - cron: '0 1 * * *'
 
 jobs:
   call-test-workflow:


### PR DESCRIPTION
If the last commit is older than 50 days old when the scheduled workflows run, then an empty commit with title 'Empty commit to keep the gihub workflows alive' is made by 'GitHub Actions Bot'.

Remove the dependency to the third party github action to keep the workflows alive.