### PR TITLE
add a flag to enable or disable plotting extra feature plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ BluePyEfe.egg-info
 /examples/output
 *.ipynb_checkpoints
 /test_run
+build

--- a/bluepyefe/extra.py
+++ b/bluepyefe/extra.py
@@ -118,7 +118,7 @@ def spikerate_tau_log(peaktimes):
     return tau
 
 
-def spikerate_slope(peaktimes):
+def spikerate_slope(peaktimes, plot=True):
     """Spike rate slope feature"""
 
     peaktimes = numpy.array(peaktimes) * 1e-3
@@ -132,17 +132,18 @@ def spikerate_slope(peaktimes):
     freq = 1. / isi
     freq = freq - freq[-1]
 
-    plt.subplot(5, 1, 1)
-    plt.plot(times, isi, '*')
-    plt.subplot(5, 1, 2)
-    plt.plot(times, log_isi, '*')
-    plt.subplot(5, 1, 3)
-    plt.plot(log_times, log_isi, '*')
-    plt.subplot(5, 1, 4)
-    plt.plot(x, log_isi, '*')
-    plt.subplot(5, 1, 5)
-    plt.plot(log_x, log_isi, '*')
-    plt.show()
+    if plot:
+        plt.subplot(5, 1, 1)
+        plt.plot(times, isi, '*')
+        plt.subplot(5, 1, 2)
+        plt.plot(times, log_isi, '*')
+        plt.subplot(5, 1, 3)
+        plt.plot(log_times, log_isi, '*')
+        plt.subplot(5, 1, 4)
+        plt.plot(x, log_isi, '*')
+        plt.subplot(5, 1, 5)
+        plt.plot(log_x, log_isi, '*')
+        plt.show()
 
     slope_log, _ = numpy.polyfit(log_x, log_isi, 1)
     slope_semilog, _ = numpy.polyfit(x, log_isi, 1)
@@ -152,7 +153,7 @@ def spikerate_slope(peaktimes):
     return slope_log
 
 
-def spikerate_tau_slope(peaktimes):
+def spikerate_tau_slope(peaktimes, plot=True):
     """Spike rate tau slope feature"""
 
     peaktimes = numpy.array(peaktimes) * 1e-3
@@ -189,13 +190,14 @@ def spikerate_tau_slope(peaktimes):
     # times = times[i_use]
     # log_freq = log_freq[i_use]
 
-    plt.subplot(3, 1, 1)
-    plt.plot(times, log_freq, '*')
-    plt.subplot(3, 1, 2)
-    plt.plot(times[1:], numpy.diff(log_freq), '*')
-    plt.subplot(3, 1, 3)
-    plt.plot(times[1:], numpy.diff(log_freq) / numpy.diff(times), '*')
-    plt.show()
+    if plot:
+        plt.subplot(3, 1, 1)
+        plt.plot(times, log_freq, '*')
+        plt.subplot(3, 1, 2)
+        plt.plot(times[1:], numpy.diff(log_freq), '*')
+        plt.subplot(3, 1, 3)
+        plt.plot(times[1:], numpy.diff(log_freq) / numpy.diff(times), '*')
+        plt.show()
 
     tau = -numpy.mean(numpy.diff(log_freq) / numpy.diff(times))
     if numpy.isnan(tau):

--- a/bluepyefe/extra.py
+++ b/bluepyefe/extra.py
@@ -123,7 +123,6 @@ def spikerate_slope(peaktimes):
 
     peaktimes = numpy.array(peaktimes) * 1e-3
     isi = numpy.diff(peaktimes)
-    isi = isi
     x = numpy.arange(1, len(isi) + 1)
 
     times = peaktimes[:-1]

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -31,7 +31,6 @@ import os
 import logging
 import gzip
 import json
-import pprint
 
 from itertools import cycle
 from collections import OrderedDict

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -62,6 +62,7 @@ class Extractor(object):
             which to extract the efeatures.
         """
 
+        self.plot_extra_features = True
         self.config = config
         self.path = config['path']
         self.cells = config['cells']
@@ -190,6 +191,9 @@ class Extractor(object):
         self.extra_features = ['spikerate_tau_jj', 'spikerate_drop',
                                'spikerate_tau_log', 'spikerate_tau_fit',
                                'spikerate_tau_slope']
+
+    def disable_extra_feature_plots(self):
+        self.plot_extra_features = False
 
     def newmeancell(self, a):
         if (self.options["nanmean_cell"] or
@@ -543,7 +547,8 @@ class Extractor(object):
 
                         elif feature == 'spikerate_tau_slope':
                             if len(peak_times) > 4:
-                                f = extra.spikerate_tau_slope(peak_times)
+                                f = extra.spikerate_tau_slope(
+                                    peak_times, plot=self.plot_extra_features)
                             else:
                                 f = None
                         elif fel_vals[0][feature] is not None and \


### PR DESCRIPTION
This PR makes plotting of extra features configurable by the user.
The default behaviour of plotting does not change.

Users simply disable the extra feature plots by calling the following method before running the feature extraction.
`extractor.disable_extra_feature_plots()`


Motivation
-----------

* The feature plots such as `spikerate_tau_slope` are producing an overflowing amount of plots when it is called upon a group of cells, it is very hard to interpret each one of them even for a small amount of cells.
* Those plots are not always desired
* They are computationally expensive
* On the emodels paper notebook disabling them reduces the computational time by **%33**.
* They raise warnings multiple times (for each trace)
