### PR TITLE
bugfix: remove mutable default arguments

### DIFF
--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -208,8 +208,7 @@ class Extractor(object):
         else:
             return numpy.std(a)
 
-    def boxcoxcell(self, a, nanopt="nanmean_cell",
-                   lm_vec=numpy.linspace(-3, 3, 41)):
+    def boxcoxcell(self, a, nanopt="nanmean_cell"):
         if ((self.options[nanopt] or
              (numpy.sum(numpy.isnan(a)) <= self.options["nangrace"])) and
                 (len(a) > 0)):

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -53,7 +53,7 @@ class Extractor(object):
 
     """Extractor class"""
 
-    def __init__(self, mainname='PC', config=OrderedDict()):
+    def __init__(self, mainname='PC', config=None):
         """Constructor
 
         Args:
@@ -62,6 +62,8 @@ class Extractor(object):
             config (dict): metadata containing the protocols and cells for
             which to extract the efeatures.
         """
+        if config is None:
+            config = OrderedDict()
 
         self.config = config
         self.path = config['path']

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -31,7 +31,6 @@ import os
 import logging
 import gzip
 import json
-import pprint
 
 from itertools import cycle
 from collections import OrderedDict

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -707,7 +707,6 @@ class Extractor(object):
 
                 hypamp = dataset_cell_exp[expname]['hypamp']
                 amp = dataset_cell_exp[expname]['amp']
-                numspikes = dataset_cell_exp[expname]['features']['numspikes']
                 feature_array = dataset_cell_exp[expname]['features']
 
                 rawfiles_list = dataset_cell_exp[expname]['rawfiles']
@@ -1057,8 +1056,6 @@ class Extractor(object):
                         str(target)]
                     cell_std_feat = self.dataset_mean[expname][
                         'cell_std_features'][feature][str(target)]
-                    cell_n = self.dataset_mean[expname]['cell_n'][feature][
-                        str(target)]
 
                     # added by Luca Leonardo Bologna to handle the case in
                     # which only one feature value is present at this point
@@ -1301,7 +1298,6 @@ class Extractor(object):
 
                     mean_array = numpy.array(mean_list)
                     std_array = numpy.array(std_list)
-                    amp_rel_array = numpy.array(amp_rel_list)
 
                     figname = "features_" + expname
                     e = figs[figname]['axs'][fi].errorbar(

--- a/bluepyefe/formats/axon.py
+++ b/bluepyefe/formats/axon.py
@@ -20,7 +20,6 @@ Copyright (c) 2020, EPFL/Blue Brain Project
 """
 
 from neo import io
-from collections import OrderedDict
 import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/bluepyefe/formats/axon.py
+++ b/bluepyefe/formats/axon.py
@@ -284,7 +284,7 @@ def process(config=None,
                 data=data, voltage=voltage, current=current, dt=dt, t=t,
                 ton=ton, toff=toff, amp=amp, hypamp=hypamp,
                 filename=filename)
-    resp_check = check_validity(data)
+    resp_check = check_validity(data, filename)
 
     return data
 
@@ -451,7 +451,7 @@ def get_nbepisod(header):
 
 
 #
-def check_validity(data):
+def check_validity(data, filename):
     # extract number of traces
     nb_traces = len(data["voltage"])
 

--- a/bluepyefe/formats/axon.py
+++ b/bluepyefe/formats/axon.py
@@ -130,7 +130,7 @@ def process(config=None,
         stim_info_flag = True
         try:
             sampling_rate = 1.e6 / header['protocol']['fADCSequenceInterval']
-        except Exception as e:
+        except Exception:
             logger.info(
                 "Unable to find recording frequency in file: %s." +
                 "The ABF file version is probably older than v2", filename)
@@ -247,9 +247,6 @@ def process(config=None,
 
             # estimate hyperpolarization current
             hypamp = numpy.mean(current[0:ion])
-
-            # 10% distance to measure step current
-            iborder = int((ioff - ion) * 0.1)
 
             # clean voltage from transients
             voltage[ion:ion + int(numpy.ceil(0.4 / dt))] = \

--- a/bluepyefe/formats/common.py
+++ b/bluepyefe/formats/common.py
@@ -551,14 +551,12 @@ class manageDicts():
         return data
 
     @classmethod
-    def fill_dict_single_trace(
-            cls, data={}, voltage=0.0, current=0.0, dt=0.0, t=0.0, ton=0.0,
-            toff=0.0, amp=0.0, hypamp=0.0, filename=""):
-
+    def fill_dict_single_trace(cls, data=None, voltage=0.0, current=0.0, dt=0.0, t=0.0, ton=0.0, toff=0.0, amp=0.0, hypamp=0.0, filename=""):
+        if data is None:
+            data = {}
         data['voltage'].append(voltage)
         data['current'].append(current)
         data['dt'].append(dt)
-
         data['t'].append(t)
         data['tend'].append(t[-1])
         data['ton'].append(ton)
@@ -566,5 +564,4 @@ class manageDicts():
         data['amp'].append(amp)
         data['hypamp'].append(hypamp)
         data['filename'].append(filename)
-
         return True

--- a/bluepyefe/formats/common.py
+++ b/bluepyefe/formats/common.py
@@ -194,7 +194,6 @@ class manageMetadata:
         if not os.path.isfile(outfilepath):
             with open(outfilepath, 'w') as f:
                 json.dump(obj, f)
-        return
 
     @classmethod
     def generate_authorization_json(

--- a/bluepyefe/formats/common.py
+++ b/bluepyefe/formats/common.py
@@ -1,14 +1,11 @@
-from neo import io
 from collections import OrderedDict
 import os
 import json
 import hashlib
-import calendar
 import re
-import six
 import logging
 logger = logging.getLogger(__name__)
-import quantities as pq
+
 
 
 class manageFiles:

--- a/bluepyefe/formats/common.py
+++ b/bluepyefe/formats/common.py
@@ -7,7 +7,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
 class manageFiles:
     @classmethod
     def md5(cls, filename):
@@ -551,7 +550,10 @@ class manageDicts():
         return data
 
     @classmethod
-    def fill_dict_single_trace(cls, data=None, voltage=0.0, current=0.0, dt=0.0, t=0.0, ton=0.0, toff=0.0, amp=0.0, hypamp=0.0, filename=""):
+    def fill_dict_single_trace(cls, data=None, voltage=0.0, current=0.0,
+                               dt=0.0, t=0.0, ton=0.0, toff=0.0, amp=0.0,
+                               hypamp=0.0, filename=""):
+
         if data is None:
             data = {}
         data['voltage'].append(voltage)

--- a/bluepyefe/formats/igor.py
+++ b/bluepyefe/formats/igor.py
@@ -38,8 +38,6 @@ def process(config=None,
     """Read recordings from an igor file"""
 
     path = config['path']
-    cells = config['cells']
-    features = config['features']
     options = config['options']
 
     data = OrderedDict()

--- a/bluepyefe/formats/spike2.py
+++ b/bluepyefe/formats/spike2.py
@@ -65,8 +65,6 @@ def process(config=None,
             "No metadata file found for file %s. Skipping file", filename)
         return data
 
-    # read stimulus features if present
-    stim_feats = []
 
     logger.info(" Adding spike2 file %s", filename)
 

--- a/bluepyefe/formats/spike2.py
+++ b/bluepyefe/formats/spike2.py
@@ -65,7 +65,6 @@ def process(config=None,
             "No metadata file found for file %s. Skipping file", filename)
         return data
 
-
     logger.info(" Adding spike2 file %s", filename)
 
     fullfilename = filename + '.smr'

--- a/bluepyefe/formats/spike2.py
+++ b/bluepyefe/formats/spike2.py
@@ -19,18 +19,13 @@ Copyright (c) 2020, EPFL/Blue Brain Project
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from neo import io
-from collections import OrderedDict
 import logging
 logger = logging.getLogger(__name__)
 import numpy as np
 import os
 import json
-import sys
 import quantities
-from quantities import ms, s, mV, nA
-import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
+from quantities import ms, mV
 from neo import AnalogSignal
 from neo.io import Spike2IO
 from . import common

--- a/bluepyefe/plottools.py
+++ b/bluepyefe/plottools.py
@@ -101,11 +101,13 @@ def light_palette(color, n_colors=6, reverse=False, lumlight=0.8, light=None):
 
 def tiled_figure(
     figname='', frames=1, columns=2, rows_per_page=4,
-    dirname='', figs=collections.OrderedDict(), orientation='page',
+    dirname='', figs=None, orientation='page',
     width_ratios=None, height_ratios=None, hspace=0.6, wspace=0.2,
     top=0.97, bottom=0.05, left=0.07, right=0.97
 ):
 
+    if figs is None:
+        figs = collections.OrderedDict()
     if figname not in figs.keys():
 
         if orientation == 'landscape':

--- a/bluepyefe/plottools.py
+++ b/bluepyefe/plottools.py
@@ -28,7 +28,9 @@ import numpy
 import collections
 
 
-def adjust_spines(ax, spines, color='k', d_out=10, d_down=[]):
+def adjust_spines(ax, spines, color='k', d_out=10, d_down=None):
+    if d_down is None:
+        d_down = []
 
     if d_down == []:
         d_down = d_out

--- a/bluepyefe/tools/tabletools.py
+++ b/bluepyefe/tools/tabletools.py
@@ -12,7 +12,6 @@ class printFeatures:
             cls, all_feat_filename="all_features.txt", cellname="CELLNAME",
             trace_filename="", features_name=[], fel_vals=[], multvalnum=5,
             metadata={}, amp=0, stim_start=0, stim_end=0):
-        counter = 0
         param_file = os.path.join(
             os.path.dirname(__file__), cls.TT_CONFIG_PATH,
             cls.TT_CONFIG_FILE)
@@ -75,7 +74,6 @@ class printFeatures:
             else:
                 crr_feat_val = [numpy.nan] * multvalnum
                 if crr_feature is not None and len(crr_feature) > 0:
-                    crr_feat_len = len(crr_feature)
                     for y in range(multvalnum - 2):
                         if len(crr_feature) > y + 1:
                             crr_feat_val[y + 1] = crr_feature[y + 1]

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -135,16 +135,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    extractor = bpefe.Extractor('output', config)\n",
-    "    extractor.create_dataset()\n",
-    "    extractor.plt_traces()\n",
-    "    extractor.extract_features(threshold=-30.)\n",
-    "    extractor.mean_features()\n",
-    "    extractor.analyse_threshold()\n",
-    "    extractor.plt_features()\n",
-    "    extractor.feature_config_cells()\n",
-    "    extractor.feature_config_all()\n",
-    "    extractor.plt_features_dist()"
+    "extractor = bpefe.Extractor('output', config)\n",
+    "extractor.create_dataset()\n",
+    "extractor.plt_traces()\n",
+    "extractor.extract_features(threshold=-30.)\n",
+    "extractor.mean_features()\n",
+    "extractor.analyse_threshold()\n",
+    "extractor.plt_features()\n",
+    "extractor.feature_config_cells()\n",
+    "extractor.feature_config_all()\n",
+    "extractor.plt_features_dist()"
    ]
   },
   {
@@ -157,14 +157,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -176,7 +176,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.2 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -190,15 +190,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.2"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
+   }
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
    }
   }
  },


### PR DESCRIPTION
This PR removes the mutable default arguments found in multiple places in the code.

Additionally it removes some unused imports and unused variables.

References to the bug:

https://docs.python-guide.org/writing/gotchas/
https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/