### PR TITLE
add progress-bar to the extract function

### DIFF
--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -458,10 +458,10 @@ class Extractor(object):
         else:
             ZERO_TO_NAN = False
 
-        for i_cell, cellname in enumerate(self.dataset):
+        for cellname in self.dataset:
 
             dataset_cell_exp = self.dataset[cellname]['experiments']
-            for i_exp, expname in enumerate(dataset_cell_exp):
+            for expname in dataset_cell_exp:
 
                 if expname in self.options["strict_stiminterval"].keys():
                     strict_stiminterval = self.options["strict_stiminterval"][

--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -32,6 +32,8 @@ import logging
 import gzip
 import json
 
+from tqdm import tqdm
+
 from itertools import cycle
 from collections import OrderedDict
 
@@ -458,7 +460,7 @@ class Extractor(object):
         else:
             ZERO_TO_NAN = False
 
-        for cellname in self.dataset:
+        for cellname in tqdm(self.dataset):
 
             dataset_cell_exp = self.dataset[cellname]['experiments']
             for expname in dataset_cell_exp:

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setuptools.setup(
         'efel',
         'sh',
         'pandas',
-        'scipy'],
+        'scipy',
+        'tqdm'],
 )


### PR DESCRIPTION
Added a `tqdm` progress bar to the extract function to inform users on the progress and give an estimate on how much remains.
The output looks like this.

83%|████████▎ | 5/6 [00:28<00:05,  5.75s/it]