### PR TITLE
address 'keywords' should be a list, got type 'tuple' warning

### DIFF
--- a/bluepyefe/extractor.py
+++ b/bluepyefe/extractor.py
@@ -116,7 +116,7 @@ class Extractor(object):
         if "strict_stiminterval" not in self.options:
             self.options["strict_stiminterval"] = {'base': False}
 
-        if isinstance(self.options["tolerance"], list) is False:
+        if not isinstance(self.options["tolerance"], list):
             if conv_fact != 1:
                 tolerance = self.options["tolerance"]
                 self.options["tolerance"] = conv_fact * tolerance
@@ -242,7 +242,7 @@ class Extractor(object):
         """Read the trace files and add them to the dictionary self.dataset"""
         logger.info(" Filling dataset")
 
-        for i_cell, cellname in enumerate(self.cells):
+        for cellname in self.cells:
 
             self.dataset[cellname] = OrderedDict()
 
@@ -346,8 +346,7 @@ class Extractor(object):
         """Plot traces"""
         logger.info(" Plotting traces")
 
-        for i_cell, cellname in enumerate(self.dataset):
-
+        for cellname in self.dataset:
             dirname = self.maindirname + cellname
             tools.makedir(dirname)
             dataset_cell_exp = self.dataset[cellname]['experiments']

--- a/bluepyefe/plottools.py
+++ b/bluepyefe/plottools.py
@@ -72,7 +72,6 @@ def adjust_spines(ax, spines, color='k', d_out=10, d_down=None):
             ax.tick_params(axis='y', colors=color)
 
     if 'bottom' in spines:
-        pass
         ax.xaxis.set_ticks_position('bottom')
         # ax.axes.get_xaxis().set_visible(True)
 

--- a/setup.py
+++ b/setup.py
@@ -38,16 +38,15 @@ setuptools.setup(
     include_package_data=True,
     author="BlueBrain Project, EPFL",
     license="LGPLv3",
-    keywords=(
+    keywords=[
         'neuroscience',
-        'BlueBrainProject'),
+        'BlueBrainProject'],
     url='https://github.com/BlueBrain/BluePyEfe',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'License :: OSI Approved :: GNU Lesser General Public '
         'License v3 (LGPLv3)',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: POSIX',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,13 @@
 envlist = py3-{functional,style}
 [gh-actions]
 python =
-    3.6: py3
     3.7: py3
     3.8: py3
     3.9: py3
     3.10: py3
 [testenv]
 envdir =
-    py3{5,6,7,8,9,10,}{-functional,-style,-syntax,-devpi,-docs,-upload_docs}: {toxworkdir}/py3
+    py3{7,8,9,10,}{-functional,-style,-syntax,-devpi,-docs,-upload_docs}: {toxworkdir}/py3
 deps =
     coverage
     pytest


### PR DESCRIPTION
Minor changes

- Addresses the 'keywords' should be a list, got type 'tuple' warning raised each time the version is queried
- remove unsupported python versions 3.5 and 3.6 from ci
- remove a few unnecessary statements in the code