### PR TITLE
BPE2: address 'keywords' should be a list, got type 'tuple' warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,16 +38,15 @@ setuptools.setup(
     include_package_data=True,
     author="BlueBrain Project, EPFL",
     license="LGPLv3",
-    keywords=(
+    keywords=[
         'neuroscience',
-        'BlueBrainProject'),
+        'BlueBrainProject'],
     url='https://github.com/BlueBrain/BluePyEfe',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'License :: OSI Approved :: GNU Lesser General Public '
         'License v3 (LGPLv3)',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Operating System :: POSIX',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Minor update to rid the persistent warning message that is raised each time the version is queried.

BEFORE
```
> python setup.py --version
Warning: 'keywords' should be a list, got type 'tuple'
2.1.2
```

AFTER
```
> python setup.py --version
2.1.2
```