### PR TITLE
force numpy<1.24 until igor is updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         'Topic :: Scientific/Engineering',
         'Topic :: Utilities'],
     install_requires=[
-        'numpy',
+        'numpy<1.24',
         'neo',
         'matplotlib',
         'efel',


### PR DESCRIPTION
Numpy 1.24 has introduced a change that makes igor break. We have to use numpy<1.24 until igor is updated to support numpy1.24+. See https://github.com/wking/igor/pull/4