### PR TITLE
Fix smoothing for current amplitude detection

### DIFF
--- a/bluepyefe/ecode/tools.py
+++ b/bluepyefe/ecode/tools.py
@@ -19,11 +19,11 @@ Copyright (c) 2022, EPFL/Blue Brain Project
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 import numpy
-from scipy.signal import medfilt2d
+from scipy.ndimage import median_filter
 
 
 def scipy_signal2d(data, width):
-    return medfilt2d(data.reshape(1, -1), (1, width))[0].tolist()
+    return median_filter(data, size=width).tolist()
 
 
 def base_current(current, idx_ton=300):

--- a/tests/test_ecode_tools.py
+++ b/tests/test_ecode_tools.py
@@ -1,0 +1,31 @@
+from bluepyefe.ecode import tools
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
+
+
+def test_scipy_signal2d():
+    np.random.seed(42)
+    data = np.random.uniform(-1, 1, 10)
+    res = tools.scipy_signal2d(data, 85)
+    assert_array_almost_equal(
+        res,
+        [
+            0.2022300234864176,
+            0.1973169683940732,
+            0.1973169683940732,
+            0.1973169683940732,
+            0.1973169683940732,
+            0.1973169683940732,
+            0.1973169683940732,
+            0.2022300234864176,
+            0.2022300234864176,
+            0.2022300234864176,
+        ],
+    )
+
+
+def test_base_current():
+    np.random.seed(42)
+    data = np.random.uniform(-1, 1, 10)
+    base = tools.base_current(data)
+    assert_almost_equal(base, 0.1973169683940732)


### PR DESCRIPTION
The base_current function was using the smoothing by default, which is hardcoded to be off in the code (bad bad btw!). I make it follow the main function (and off by default). 
I have traces where the `scipy_signal2d` makes the current = [0, 0, 0, 0], hence completely screwing up the estimation of the current amplitude. 

For example an IV trace with a positive current injection was used as a IV_-20 protocol to estimate the Rin, leading to Rin of -150