### PR TITLE
add readthedocs.yml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"


### PR DESCRIPTION
motivation: readthedocs uses python3.7 but igor2 requires python>=3.8

Precising python version in new .readthedocs.yml file should solve this problem and make readthedocs work once again.