### PR TITLE
Readthedocs install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,4 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: requirements_docs.txt

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,16 @@
+# Copyright 2020-2023 Blue Brain Project / EPFL
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sphinx>=2.0.0
+sphinx-bluebrain-theme

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """BluePyEfe setup """
 
 """
-Copyright (c) 2020, EPFL/Blue Brain Project
+Copyright (c) 2020-2023, EPFL/Blue Brain Project
 
  This file is part of BluePyEfe <https://github.com/BlueBrain/BluePyEfe>
 


### PR DESCRIPTION
readthedocs now fails with missing sphinx-bluebrain-theme requirement. This should fix it.