### PR TITLE
modify step threshold in step detection of sAHP

### DIFF
--- a/bluepyefe/ecode/sAHP.py
+++ b/bluepyefe/ecode/sAHP.py
@@ -138,7 +138,7 @@ class SAHP(Recording):
 
         # Set the threshold to detect the step
         noise_level = numpy.std(numpy.concatenate((self.current[:50], self.current[-50:])))
-        step_threshold = numpy.max([4.5 * noise_level, 1e-5])
+        step_threshold = numpy.max([3.0 * noise_level, 1e-5])
 
         # The buffer prevent miss-detection of the step when artifacts are
         # present at the very start or very end of the current trace

--- a/bluepyefe/ecode/sAHP.py
+++ b/bluepyefe/ecode/sAHP.py
@@ -138,7 +138,7 @@ class SAHP(Recording):
 
         # Set the threshold to detect the step
         noise_level = numpy.std(numpy.concatenate((self.current[:50], self.current[-50:])))
-        step_threshold = numpy.max([3.0 * noise_level, 1e-5])
+        step_threshold = numpy.max([2.0 * noise_level, 1e-5])
 
         # The buffer prevent miss-detection of the step when artifacts are
         # present at the very start or very end of the current trace


### PR DESCRIPTION
When user has info about step start and end, s/he should inform it to bluepyefe, because automatic step detection cannot always properly detect steps, especially when the trace is noisy and the step amplitude is low.

This PR fixes step detection for a particular trace that made bluepyefe crash. The number 2.0 is ad hoc (as was previously 4.5) and fine tuned by hand to allow a maximum of traces to be properly detected. I tested this on 211 traces from the rat primary somatosensory cortex recorded by lnmc.
With 2.0, only 3 traces had ton and toff not properly detected, and bluepyefe did not crash. With a value less than 2.0, we start having tmid and tmid2 values not being properly detected for several traces. With a value larger than 2.0, we have more ton and toff not properly detected.