### PR TITLE
Force evaluation for built-in map()

### DIFF
--- a/bluepyefe/plotting.py
+++ b/bluepyefe/plotting.py
@@ -115,7 +115,6 @@ def _plot(cell, output_dir, show=False):
 
 def plot_all_recordings(cells, output_dir, show=False, mapper=map):
     """Plot recordings for all cells and all protocols"""
-    mapper(partial(_plot, output_dir=output_dir, show=show), cells)
     if mapper == map:
         # For the built-in map(), ensure immediate evaluation as it returns a lazy iterator
         # which won't execute the function until iterated over. Converting to a list forces this iteration.

--- a/bluepyefe/plotting.py
+++ b/bluepyefe/plotting.py
@@ -116,6 +116,12 @@ def _plot(cell, output_dir, show=False):
 def plot_all_recordings(cells, output_dir, show=False, mapper=map):
     """Plot recordings for all cells and all protocols"""
     mapper(partial(_plot, output_dir=output_dir, show=show), cells)
+    if mapper == map:
+        # For the built-in map(), ensure immediate evaluation as it returns a lazy iterator
+        # which won't execute the function until iterated over. Converting to a list forces this iteration.
+        list(mapper(partial(_plot, output_dir=output_dir, show=show), cells))
+    else:
+        mapper(partial(_plot, output_dir=output_dir, show=show), cells)
 
 
 def plot_efeature(


### PR DESCRIPTION
When using the built-in map() function, force immediate evaluation by converting its lazy iterator result to a list. This ensures that the _plot function is executed immediately when using the standard map() but remains unchanged for other mappers.