### PR TITLE
ecodes with amp2 output fix

### DIFF
--- a/bluepyefe/ecode/DeHyperPol.py
+++ b/bluepyefe/ecode/DeHyperPol.py
@@ -31,6 +31,9 @@ class DeHyperPol(Recording):
 
     """DeHyperpol current stimulus
 
+    The hyperpolarizing step is usually fixed at 150% of rheobase, and the hyperpolarizing step
+    can usually vary from -40% to -160% of rheobase
+
          hypamp        hypamp+amp      hypamp+amp2    hypamp
            :                :               :            :
            :         _________________      :            :

--- a/bluepyefe/ecode/DeHyperPol.py
+++ b/bluepyefe/ecode/DeHyperPol.py
@@ -32,7 +32,7 @@ class DeHyperPol(Recording):
     """DeHyperpol current stimulus
 
     The hyperpolarizing step is usually fixed at 150% of rheobase, and the hyperpolarizing step
-    can usually vary from -40% to -160% of rheobase
+    can usually vary from -40% to -160% of rheobase.
 
          hypamp        hypamp+amp      hypamp+amp2    hypamp
            :                :               :            :

--- a/bluepyefe/ecode/DeHyperPol.py
+++ b/bluepyefe/ecode/DeHyperPol.py
@@ -89,9 +89,10 @@ class DeHyperPol(Recording):
         ecode_params = {
             "delay": self.ton,
             "tmid": self.tmid,
+            "toff": self.toff,
             "amp": self.amp,
             "amp2": self.amp2,
-            "thresh_perc": self.amp_rel,
+            "thresh_perc": self.amp2_rel,
             "duration": self.toff - self.ton,
             "totduration": self.tend,
         }

--- a/bluepyefe/ecode/HyperDePol.py
+++ b/bluepyefe/ecode/HyperDePol.py
@@ -95,7 +95,7 @@ class HyperDePol(Recording):
             "toff": self.toff,
             "amp": self.amp,
             "amp2": self.amp2,
-            "thresh_perc": self.amp2_rel,
+            "thresh_perc": self.amp_rel,
             "duration": self.toff - self.ton,
             "totduration": self.tend,
         }

--- a/bluepyefe/ecode/HyperDePol.py
+++ b/bluepyefe/ecode/HyperDePol.py
@@ -31,6 +31,9 @@ class HyperDePol(Recording):
 
     """HyperDepol current stimulus
 
+    The hyperpolarizing step is usually fixed at 100% of rheobase, and the hyperpolarizing step
+    can usually vary from -40% to -160% of rheobase.
+
 
           hypamp         hypamp+amp           hypamp+amp2         hypamp
             :                :                     :                :

--- a/bluepyefe/ecode/negCheops.py
+++ b/bluepyefe/ecode/negCheops.py
@@ -96,6 +96,11 @@ class NegCheops(Recording):
         """Returns the eCode parameters"""
         ecode_params = {
             "delay": self.ton,
+            "t1": self.t1,
+            "t2": self.t2,
+            "t3": self.t3,
+            "t4": self.t4,
+            "toff": self.toff,
             "amp": self.amp,
             "thresh_perc": self.amp_rel,
             "duration": self.toff - self.ton,

--- a/bluepyefe/ecode/sAHP.py
+++ b/bluepyefe/ecode/sAHP.py
@@ -32,6 +32,9 @@ class SAHP(Recording):
 
     """sAHP current stimulus
 
+    The long step (here amp) is usually fixed at 40% of rheobase, and the short step (here amp2)
+    can usually vary from 150% to 300% of rheobase.
+
 
        hypamp        hypamp+amp       hypamp+amp2        hypamp+amp           hypamp
          :                :                :                 :                   :

--- a/bluepyefe/protocol.py
+++ b/bluepyefe/protocol.py
@@ -192,6 +192,9 @@ class Protocol():
             if key == "amp" and self.global_rheobase:
                 amp_rel = operator([c["amp_rel"] for c in params])
                 mean_param = float(amp_rel) * self.global_rheobase / 100.
+            elif key == "amp2" and self.global_rheobase:
+                amp_rel2 = operator([c["amp_rel2"] for c in params])
+                mean_param = float(amp_rel2) * self.global_rheobase / 100.
             else:
                 mean_param = operator([numpy.nan if c[key] is None else c[key] for c in params])
 


### PR DESCRIPTION
- Fixes output of DeHyperPol, HyperDePol and negCheops so that thresh_perc represent the amplitude that is not fixed
- Add some docstrings to ecodes better describing the ecodes
- edge case for mean of amp2 with relative amplitude
