### PR TITLE
Make BluePyEfe compatible with numpy2

### DIFF
--- a/bluepyefe/tools.py
+++ b/bluepyefe/tools.py
@@ -156,7 +156,7 @@ class NumpyEncoder(json.JSONEncoder):
         ):
             return int(obj)
         elif isinstance(
-            obj, (numpy.float_, numpy.float16, numpy.float32, numpy.float64)
+            obj, (numpy.float16, numpy.float32, numpy.float64)
         ):
             return float(obj)
         elif isinstance(obj, numpy.ndarray):


### PR DESCRIPTION
numpy.float_ is deprecated in numpy2: https://numpy.org/devdocs/numpy_2_0_migration_guide.html