### PR TITLE
allow stimulus_description in ScalaNWBReader

### DIFF
--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -116,7 +116,7 @@ class ScalaNWBReader(NWBReader):
             key_current = sweep.replace('Series', 'StimulusSeries')
             try:
                 protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
-            except AttributeError:
+            except KeyError:
                 logger.warning(f'Could not find "stimulus_description" attribute for {sweep}, Setting it as "Step"')
                 protocol_name = "Step"
 

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -116,7 +116,7 @@ class ScalaNWBReader(NWBReader):
             key_current = sweep.replace('Series', 'StimulusSeries')
             try:
                 protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
-            except:
+            except AttributeError:
                 logger.warning(f'Could not find "stimulus_description" attribute for {sweep}, Setting it as "Step"')
                 protocol_name = "Step"
 

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -114,7 +114,12 @@ class ScalaNWBReader(NWBReader):
 
         for sweep in list(self.content['acquisition'].keys()):
             key_current = sweep.replace('Series', 'StimulusSeries')
-            protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
+            try:
+                protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
+            except:
+                logger.warning(f'Could not find "stimulus_description" attribute for {sweep}, Setting it as "Step"')
+                protocol_name = "Step"
+
             if ("na" == protocol_name.lower()) or ("step" in protocol_name.lower()):
                 protocol_name = "Step"
 

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -115,9 +115,8 @@ class ScalaNWBReader(NWBReader):
         for sweep in list(self.content['acquisition'].keys()):
             key_current = sweep.replace('Series', 'StimulusSeries')
             protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
-            
-            if ("na"==protocol_name.lower()) or ("step" in protocol_name.lower()):
-                protocol_name ="Step"
+            if ("na" == protocol_name.lower()) or ("step" in protocol_name.lower()):
+                protocol_name = "Step"
 
             if (
                 self.target_protocols and

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -114,7 +114,10 @@ class ScalaNWBReader(NWBReader):
 
         for sweep in list(self.content['acquisition'].keys()):
             key_current = sweep.replace('Series', 'StimulusSeries')
-            protocol_name = "Step"
+            protocol_name = self.content["acquisition"][sweep].attrs["stimulus_description"]
+            
+            if ("na"==protocol_name.lower()) or ("step" in protocol_name.lower()):
+                protocol_name ="Step"
 
             if (
                 self.target_protocols and


### PR DESCRIPTION
* To get `protocol_name` from `stimulus_description` entries to allow ecodes names other than `Step`
* Preserves the default `protocol_name` `Step` for Scala files
* Tested for collaborator files for hippocampus and straitum